### PR TITLE
Add faction to tracked NS players based on outfit leader

### DIFF
--- a/src/modules/discord/bot.ts
+++ b/src/modules/discord/bot.ts
@@ -55,7 +55,9 @@ client.on('ready', () => {
       const character = await censusApi.getCharacterOutfitLeaderFaction({
         characterId,
       })
-      if (character === null) return
+      if (!character) {
+        return
+      }
 
       sendAnnouncement(
         constants.discord.channelIds.brutracker,
@@ -69,7 +71,7 @@ client.on('ready', () => {
             factionEmojis[Number(character.factionId)] ?? factionEmojis[0]
           }${
             character.factionId === '4' && character.outfitMember
-              ? ` and playing as ${
+              ? `${
                   factionEmojis[
                     Number(character.outfitMember.outfit.leader.factionId)
                   ]

--- a/src/modules/discord/bot.ts
+++ b/src/modules/discord/bot.ts
@@ -15,7 +15,6 @@ import {
 import { formatWithEmojis, getTextChannel } from '@discord/utils'
 import { censusApi } from '@planetside/CensusApi'
 import { streamingApi } from '@planetside/StreamingApi'
-import { Character } from '@planetside/types'
 
 /**
  * Sends a message with UTC timestamp and optionally an emoji.
@@ -51,29 +50,12 @@ client.on('ready', () => {
     '{emoji:faction_logo_ns|NS}',
   ]
 
-  type CharacterWithOutfitWithLeader = Character & {
-    outfitMember?: {
-      outfitId: string
-      outfit: {
-        leaderCharacterId: string
-        leader: {
-          factionId: string
-        }
-      }
-    }
-  }
-
   streamingApi.on('playerLogin', async ({ characterId }) => {
     if (bruCharactersDatabase.get(characterId)) {
-      const list = (await censusApi.getList(
-        'character',
-        { characterId },
-        {
-          join: 'outfit_member^show:outfit_id^inject_at:outfit_member(outfit^inject_at:outfit^show:leader_character_id(character^on:leader_character_id^to:character_id^show:faction_id^inject_at:leader))',
-        },
-      )) as CharacterWithOutfitWithLeader[]
-      if (list.length === 0) return
-      const character = list[0]
+      const character = await censusApi.getCharacterOutfitLeaderFaction({
+        characterId,
+      })
+      if (character === null) return
 
       sendAnnouncement(
         constants.discord.channelIds.brutracker,

--- a/src/modules/planetside/CensusApi.ts
+++ b/src/modules/planetside/CensusApi.ts
@@ -18,6 +18,7 @@ import {
   CharacterResolvedOutfitMemberExtended,
   CharacterResolvedStatHistory,
   CharacterStatHistoryStripped,
+  CharacterWithOutfitWithLeader,
   CharactersItem,
   CharactersOnlineStatus,
   DirectiveTreeCategory,
@@ -353,6 +354,16 @@ class CensusApi {
 
     if (list.length === 0) return null
     return list
+  }
+
+  async getCharacterOutfitLeaderFaction(query: QueryObject<Character>) {
+    const list = (await censusApi.getList('character', query, {
+      join: 'outfit_member^show:outfit_id^inject_at:outfit_member(outfit^inject_at:outfit^show:leader_character_id(character^on:leader_character_id^to:character_id^show:faction_id^inject_at:leader))',
+    })) as CharacterWithOutfitWithLeader[]
+    if (list.length === 0) return null
+    const character = list[0]
+
+    return character
   }
 }
 

--- a/src/modules/planetside/types.ts
+++ b/src/modules/planetside/types.ts
@@ -220,3 +220,15 @@ export type FullCharacterWeaponStats = {
   weaponStatsByFaction: CharacterWeaponStatsByFaction[]
   weaponStats: CharacterWeaponStats[]
 }
+
+export type CharacterWithOutfitWithLeader = Character & {
+  outfitMember?: {
+    outfitId: string
+    outfit: {
+      leaderCharacterId: string
+      leader: {
+        factionId: string
+      }
+    }
+  }
+}


### PR DESCRIPTION
Introduce playing faction for tracked NSO players based on the faction of their outfit leader. 

Currently, If the tracked NSO player is not a member of an outfit, the playing as <faction> will not be displayed.