### PR TITLE
fix/second faction would not show on log off

### DIFF
--- a/src/modules/discord/bot.ts
+++ b/src/modules/discord/bot.ts
@@ -68,7 +68,9 @@ client.on('ready', () => {
   })
   streamingApi.on('playerLogout', async ({ characterId }) => {
     if (bruCharactersDatabase.get(characterId)) {
-      const character = await censusApi.getCharacter({ characterId })
+      const character = await censusApi.getCharacterOutfitLeaderFaction({
+        characterId,
+      })
       if (!character) {
         return
       }


### PR DESCRIPTION
It just felt wrong to be missing the second faction of NS characters on player log off.
![image](https://user-images.githubusercontent.com/88556823/220714170-1646a03e-ad5e-4a5f-bdef-820a8d9d90ed.png)

I didn't test my change but I can't believe it doesn't work.